### PR TITLE
Fixed #1

### DIFF
--- a/src/app/code/community/MageProfis/OneCheckout/Block/Checkout/Agreements.php
+++ b/src/app/code/community/MageProfis/OneCheckout/Block/Checkout/Agreements.php
@@ -1,0 +1,5 @@
+<?php
+
+class MageProfis_OneCheckout_Block_Checkout_Agreements extends MageProfis_OneCheckout_Block_Checkout_Agreements_Abstract
+{
+}

--- a/src/app/code/community/MageProfis/OneCheckout/Block/Checkout/Agreements/Abstract.php
+++ b/src/app/code/community/MageProfis/OneCheckout/Block/Checkout/Agreements/Abstract.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * If FireGento_MageSetup is installed use their Checkout_Agreements
+ * block class, otherwise use standard.
+ */
+
+// @codingStandardsIgnoreStart
+if (Mage::getConfig()->getModuleConfig('FireGento_MageSetup')->is('active', 'true')) {
+
+    abstract class MageProfis_OneCheckout_Block_Checkout_Agreements_Abstract
+        extends FireGento_MageSetup_Block_Checkout_Agreements
+    {
+    }
+
+} else {
+
+    abstract class MageProfis_OneCheckout_Block_Checkout_Agreements_Abstract
+        extends Mage_Checkout_Block_Agreements
+    {
+    }
+
+}
+// @codingStandardsIgnoreEnd

--- a/src/app/code/community/MageProfis/OneCheckout/etc/config.xml
+++ b/src/app/code/community/MageProfis/OneCheckout/etc/config.xml
@@ -36,17 +36,6 @@
                 </rewrite>
             </checkout>
         </helpers>
-        <events>
-            <core_layout_update_updates_get_after>
-                <observers>
-                    <onecheckout>
-                        <type>singleton</type>
-                        <class>onecheckout/observer</class>
-                        <method>addLayoutXml</method>
-                    </onecheckout>
-                </observers>
-            </core_layout_update_updates_get_after>
-        </events>
     </global>
     <adminhtml>
         <translate>
@@ -148,6 +137,17 @@
                     </onecheckout>
                 </observers>
             </checkout_type_onepage_save_order>
+
+            <!-- Add another layout.xml if Webcomm_Boilerplate is installed -->
+            <core_layout_update_updates_get_after>
+                <observers>
+                    <onecheckout>
+                        <type>singleton</type>
+                        <class>onecheckout/observer</class>
+                        <method>addLayoutXml</method>
+                    </onecheckout>
+                </observers>
+            </core_layout_update_updates_get_after>
         </events>
     </frontend>
     <default>

--- a/src/app/design/frontend/base/default/layout/onecheckout.xml
+++ b/src/app/design/frontend/base/default/layout/onecheckout.xml
@@ -59,7 +59,7 @@
                         </action>
                     </block>
                 </block>
-                <block type="checkout/agreements" name="checkout.onepage.agreements" as="agreements" template="checkout/onepage/agreements.phtml"/>
+                <block type="onecheckout/checkout_agreements" name="checkout.onepage.agreements" as="agreements" template="checkout/onepage/agreements.phtml"/>
                 <block type="core/template" name="checkout.onepage.review.button" as="button" template="checkout/onepage/review/button.phtml"/>
                 <block type="checkout/onepage_review_info" name="review" template="onecheckout/review/info.phtml">
                     <action method="addItemRender">
@@ -97,8 +97,8 @@
             </action>
         </reference>
     </onecheckout_index_index>
-    <!-- 
-          this is done by a controller 
+    <!--
+          this is done by a controller
           reason: mxperts noregion removes this layout
     -->
     <!-- <checkout_cart_index>


### PR DESCRIPTION
Added abstract block class that uses either `FireGento_MageSetup_Block_Checkout_Agreements` or `Mage_Checkout_Block_Agreements` as parent class.
