### PR TITLE
Fix report error

### DIFF
--- a/src/app/code/community/MageProfis/OneCheckout/controllers/IndexController.php
+++ b/src/app/code/community/MageProfis/OneCheckout/controllers/IndexController.php
@@ -104,7 +104,11 @@ extends Mage_Checkout_Controller_Action
                 $data = array(
                     "method" => $firstPaymentMethod,
                 );
-                $this->getCheckout()->savePayment($data);
+                try {
+                    $this->getCheckout()->savePayment($data);
+                } catch(Exception $e){
+                    $this->getCheckout()->savePayment();
+                }
             }
         }
 


### PR DESCRIPTION
Fix this error:

```
a:5:{i:0;s:50:"Die angeforderte Zahlungsart ist nicht verfügbar.";i:1;s:1483:"#0 /app/code/core/Mage/Sales/Model/Quote/Payment.php(153): Mage::throwException('Die angefordert...')
#1 /app/code/core/Mage/Checkout/Model/Type/Onepage.php(659): Mage_Sales_Model_Quote_Payment->importData(Array)
#2 /.modman/MageProfis_OneCheckout/src/app/code/community/MageProfis/OneCheckout/controllers/IndexController.php(110): Mage_Checkout_Model_Type_Onepage->savePayment(Array)
#3 /.modman/MageProfis_OneCheckout/src/app/code/community/MageProfis/OneCheckout/controllers/IndexController.php(32): MageProfis_OneCheckout_IndexController->initCheckout()
#4 /app/code/core/Mage/Core/Controller/Varien/Action.php(418): MageProfis_OneCheckout_IndexController->indexAction()
#5 /app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(254): Mage_Core_Controller_Varien_Action->dispatch('index')
#6 /app/code/core/Mage/Core/Controller/Varien/Front.php(172): Mage_Core_Controller_Varien_Router_Standard->match(Object(Mage_Core_Controller_Request_Http))
#7 /app/code/core/Mage/Core/Model/App.php(365): Mage_Core_Controller_Varien_Front->dispatch()
#8 /app/Mage.php(684): Mage_Core_Model_App->run(Array)
#9 /index.php(83): Mage::run('', '')
#10 {main}";s:3:"url";s:13:"/onecheckout/";s:11:"script_name";s:10:"/index.php";s:4:"skin";s:7:"default";}
```
